### PR TITLE
Add parameter for image description; Refactor library core

### DIFF
--- a/examples/cli/main.go
+++ b/examples/cli/main.go
@@ -38,7 +38,7 @@ func main() {
 			MaxTokens:   *maxTokens,
 		}).
 		SetPrompt(*prompt).
-		Execute(context.Background(), agency.NewMessage(agency.UserRole, agency.TextKind, []byte(content)))
+		Execute(context.Background(), agency.NewTextMessage(agency.UserRole, content))
 
 	if err != nil {
 		fmt.Println(err)

--- a/examples/custom_operation/main.go
+++ b/examples/custom_operation/main.go
@@ -17,11 +17,7 @@ func main() {
 		increment,
 	).Execute(
 		context.Background(),
-		agency.NewMessage(
-			agency.UserRole,
-			agency.TextKind,
-			[]byte("0"),
-		),
+		agency.NewTextMessage(agency.UserRole, "0"),
 	)
 	if err != nil {
 		panic(err)
@@ -36,5 +32,5 @@ func incrementFunc(ctx context.Context, msg agency.Message, _ *agency.OperationC
 		return nil, err
 	}
 	inc := strconv.Itoa(int(i) + 1)
-	return agency.NewMessage(agency.ToolRole, agency.TextKind, []byte(inc)), nil
+	return agency.NewTextMessage(agency.ToolRole, inc), nil
 }

--- a/examples/func_call/main.go
+++ b/examples/func_call/main.go
@@ -69,7 +69,7 @@ Examples:
 	// test for first function call
 	answer, err := t2tOp.Execute(
 		ctx,
-		agency.NewMessage(agency.UserRole, agency.TextKind, []byte("what is the meaning of life?")),
+		agency.NewTextMessage(agency.UserRole, "what is the meaning of life?"),
 	)
 	if err != nil {
 		panic(err)
@@ -79,7 +79,7 @@ Examples:
 	// test for second function call
 	answer, err = t2tOp.Execute(
 		ctx,
-		agency.NewMessage(agency.UserRole, agency.TextKind, []byte("1+1?")),
+		agency.NewTextMessage(agency.UserRole, "1+1?"),
 	)
 	if err != nil {
 		panic(err)
@@ -89,7 +89,7 @@ Examples:
 	// test for both function calls at the same time
 	answer, err = t2tOp.Execute(
 		ctx,
-		agency.NewMessage(agency.UserRole, agency.TextKind, []byte("1+1 and what is the meaning of life?")),
+		agency.NewTextMessage(agency.UserRole, "1+1 and what is the meaning of life?"),
 	)
 	if err != nil {
 		panic(err)

--- a/examples/image_to_stream/main.go
+++ b/examples/image_to_stream/main.go
@@ -27,7 +27,7 @@ func main() {
 		SetPrompt("describe what you see").
 		Execute(
 			context.Background(),
-			agency.NewMessage(agency.UserRole, agency.ImageKind, imgBytes),
+			agency.NewImageMessage(agency.UserRole, imgBytes, ""),
 		)
 	if err != nil {
 		panic(err)

--- a/examples/image_to_text/main.go
+++ b/examples/image_to_text/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sashabaranov/go-openai"
 )
 
-func main() { 
+func main() {
 	imgBytes, err := os.ReadFile("example.png")
 	if err != nil {
 		panic(err)
@@ -22,7 +22,7 @@ func main() {
 		SetPrompt("describe what you see").
 		Execute(
 			context.Background(),
-			agency.NewMessage(agency.UserRole, agency.ImageKind, imgBytes),
+			agency.NewImageMessage(agency.UserRole, imgBytes, ""),
 		)
 	if err != nil {
 		panic(err)

--- a/examples/image_to_text/main.go
+++ b/examples/image_to_text/main.go
@@ -22,7 +22,8 @@ func main() {
 		SetPrompt("describe what you see").
 		Execute(
 			context.Background(),
-			agency.NewImageMessage(agency.UserRole, imgBytes, ""),
+			// FIXME description not implemented properly and lead to 400 error
+			agency.NewImageMessage(agency.UserRole, imgBytes, "example.png"),
 		)
 	if err != nil {
 		panic(err)

--- a/examples/json_message/main.go
+++ b/examples/json_message/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	_ "github.com/joho/godotenv/autoload"
+	go_openai "github.com/sashabaranov/go-openai"
+
+	"github.com/neurocult/agency"
+	"github.com/neurocult/agency/providers/openai"
+)
+
+type UserStruct struct {
+	Age  int    `json:"age"`
+	Name string `json:"name"`
+	City string `json:"city"`
+}
+
+func main() {
+	op := openai.
+		New(openai.Params{Key: os.Getenv("OPENAI_API_KEY")}).
+		TextToText(openai.TextToTextParams{Model: go_openai.GPT4oMini}).
+		SetPrompt("You are a poet that writes poetry about the user's data")
+
+	userMsg, err := agency.NewJSONTextMessage(
+		agency.UserRole,
+		UserStruct{Name: "John", Age: 30, City: "New York"},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	result, err := op.Execute(context.Background(), userMsg)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(result.Content()))
+}

--- a/examples/logging/main.go
+++ b/examples/logging/main.go
@@ -22,7 +22,7 @@ func main() {
 	).
 		Execute(
 			context.Background(),
-			agency.NewMessage(agency.UserRole, agency.TextKind, []byte("Kazakhstan alga!")),
+			agency.NewTextMessage(agency.UserRole, "Kazakhstan alga!"),
 			Logger,
 		)
 

--- a/examples/prompt_template/main.go
+++ b/examples/prompt_template/main.go
@@ -22,7 +22,7 @@ func main() {
 		).
 		Execute(
 			context.Background(),
-			agency.NewMessage(agency.UserRole, agency.TextKind, []byte("I love programming.")),
+			agency.NewTextMessage(agency.UserRole, "I love programming."),
 		)
 
 	if err != nil {

--- a/examples/rag_vector_database/main.go
+++ b/examples/rag_vector_database/main.go
@@ -36,7 +36,7 @@ func main() {
 		retrieve,
 		summarize,
 		voice,
-	).Execute(ctx, agency.NewMessage(agency.UserRole, agency.TextKind, []byte("programming")))
+	).Execute(ctx, agency.NewTextMessage(agency.UserRole, "programming"))
 	if err != nil {
 		panic(err)
 	}
@@ -76,10 +76,9 @@ func RAGoperation(client *weaviate.Client) *agency.Operation {
 			content += string(bb)
 		}
 
-		return agency.NewMessage(
+		return agency.NewTextMessage(
 			agency.AssistantRole,
-			agency.TextKind,
-			[]byte(content),
+			content,
 		), nil
 	})
 }
@@ -103,9 +102,9 @@ func prepareDB(openAPIKey string, ctx context.Context) (*weaviate.Client, error)
 	classObj := &models.Class{
 		Class:      "Records",
 		Vectorizer: "text2vec-openai",
-		ModuleConfig: map[string]interface{}{
-			"text2vec-openai":   map[string]interface{}{},
-			"generative-openai": map[string]interface{}{},
+		ModuleConfig: map[string]any{
+			"text2vec-openai":   map[string]any{},
+			"generative-openai": map[string]any{},
 		},
 	}
 	if err = client.Schema().ClassCreator().WithClass(classObj).Do(context.Background()); err != nil {

--- a/examples/speech_to_text/main.go
+++ b/examples/speech_to_text/main.go
@@ -26,7 +26,7 @@ func main() {
 		Model: goopenai.Whisper1,
 	}).Execute(
 		context.Background(),
-		agency.NewMessage(agency.UserRole, agency.VoiceKind, data),
+		agency.NewVoiceMessage(agency.UserRole, data),
 	)
 
 	if err != nil {

--- a/examples/speech_to_text_multi_model/main.go
+++ b/examples/speech_to_text_multi_model/main.go
@@ -52,7 +52,7 @@ func main() {
 	}
 
 	ctx := context.Background()
-	speechMsg := agency.NewMessage(agency.UserRole, agency.VoiceKind, sound)
+	speechMsg := agency.NewVoiceMessage(agency.UserRole, sound)
 
 	_, err = agency.NewProcess(
 		hear,

--- a/examples/speech_to_text_to_image/main.go
+++ b/examples/speech_to_text_to_image/main.go
@@ -28,7 +28,7 @@ func main() {
 			Model:     goopenai.CreateImageModelDallE2,
 			ImageSize: goopenai.CreateImageSize256x256,
 		}),
-	).Execute(context.Background(), agency.NewMessage(agency.UserRole, agency.VoiceKind, data))
+	).Execute(context.Background(), agency.NewVoiceMessage(agency.UserRole, data))
 	if err != nil {
 		panic(err)
 	}

--- a/examples/text_to_image_dalle2/main.go
+++ b/examples/text_to_image_dalle2/main.go
@@ -26,7 +26,7 @@ func main() {
 		Style:     "vivid",
 	}).Execute(
 		context.Background(),
-		agency.NewMessage(agency.UserRole, agency.TextKind, []byte("Halloween night at a haunted museum")),
+		agency.NewTextMessage(agency.UserRole, "Halloween night at a haunted museum"),
 	)
 	if err != nil {
 		panic(err)

--- a/examples/text_to_speech/main.go
+++ b/examples/text_to_speech/main.go
@@ -11,12 +11,12 @@ import (
 )
 
 func main() {
-	input := agency.NewMessage(
+	input := agency.NewTextMessage(
 		agency.UserRole,
-		agency.TextKind,
-		[]byte(`One does not simply walk into Mordor.
-Its black gates are guarded by more than just Orcs.
-There is evil there that does not sleep, and the Great Eye is ever watchful.`))
+		`One does not simply walk into Mordor.
+		Its black gates are guarded by more than just Orcs.
+		There is evil there that does not sleep, and the Great Eye is ever watchful.`,
+	)
 
 	msg, err := openai.New(openai.Params{Key: os.Getenv("OPENAI_API_KEY")}).
 		TextToSpeech(openai.TextToSpeechParams{

--- a/examples/text_to_stream/main.go
+++ b/examples/text_to_stream/main.go
@@ -32,11 +32,7 @@ func main() {
 		SetPrompt("Write a few sentences about topic").
 		Execute(
 			context.Background(),
-			agency.NewMessage(
-				agency.UserRole,
-				agency.TextKind,
-				[]byte("I love programming."),
-			),
+			agency.NewTextMessage(agency.UserRole, "I love programming."),
 		)
 	if err != nil {
 		panic(err)

--- a/examples/translate_text/main.go
+++ b/examples/translate_text/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	_ "github.com/joho/godotenv/autoload"
-	goopenai "github.com/sashabaranov/go-openai"
+	go_openai "github.com/sashabaranov/go-openai"
 
 	"github.com/neurocult/agency"
 	"github.com/neurocult/agency/providers/openai"
@@ -16,7 +16,7 @@ func main() {
 	factory := openai.New(openai.Params{Key: os.Getenv("OPENAI_API_KEY")})
 
 	result, err := factory.
-		TextToText(openai.TextToTextParams{Model: goopenai.GPT4oMini}).
+		TextToText(openai.TextToTextParams{Model: go_openai.GPT4oMini}).
 		SetPrompt("You are a helpful assistant that translates English to French").
 		Execute(
 			context.Background(),

--- a/examples/translate_text/main.go
+++ b/examples/translate_text/main.go
@@ -20,11 +20,7 @@ func main() {
 		SetPrompt("You are a helpful assistant that translates English to French").
 		Execute(
 			context.Background(),
-			agency.NewMessage(
-				agency.UserRole,
-				agency.TextKind,
-				[]byte("I love programming."),
-			),
+			agency.NewTextMessage(agency.UserRole, "I love programming."),
 		)
 
 	if err != nil {

--- a/messages.go
+++ b/messages.go
@@ -1,5 +1,7 @@
 package agency
 
+import "encoding/json"
+
 type Message interface {
 	Role() Role
 	Content() []byte
@@ -13,6 +15,7 @@ const (
 	ImageKind     Kind = "image"
 	VoiceKind     Kind = "voice"
 	EmbeddingKind Kind = "embedding"
+	JSONKind      Kind = "json"
 )
 
 type Role string
@@ -28,18 +31,30 @@ const (
 
 type TextMessage struct {
 	role    Role
-	content string
+	content []byte
 }
 
 func (m TextMessage) Role() Role      { return m.role }
 func (m TextMessage) Kind() Kind      { return TextKind }
-func (m TextMessage) Content() []byte { return []byte(m.content) }
+func (m TextMessage) Content() []byte { return m.content }
 
 func NewTextMessage(role Role, content string) TextMessage {
 	return TextMessage{
-		content: content,
+		content: []byte(content),
 		role:    role,
 	}
+}
+
+// NewJSONTextMessage creates a text message from anything that can be marshalled to JSON.
+func NewJSONTextMessage(role Role, content any) (TextMessage, error) {
+	bb, err := json.Marshal(content)
+	if err != nil {
+		return TextMessage{}, err
+	}
+	return TextMessage{
+		content: bb,
+		role:    role,
+	}, nil
 }
 
 // --- Image Message ---

--- a/messages.go
+++ b/messages.go
@@ -55,6 +55,9 @@ func (m ImageMessage) Kind() Kind          { return ImageKind }
 func (m ImageMessage) Content() []byte     { return m.content }
 func (m ImageMessage) Description() string { return m.description }
 
+// NewImageMessage creates new image message.
+// Empty byte slice is NOT a valid content.
+// Empty string IS valid description.
 func NewImageMessage(role Role, content []byte, description string) ImageMessage {
 	return ImageMessage{
 		content:     content,

--- a/messages.go
+++ b/messages.go
@@ -1,11 +1,9 @@
 package agency
 
-import "encoding/json"
-
 type Message interface {
 	Role() Role
 	Content() []byte
-	Kind() Kind
+	Kind() Kind // do we need this?
 }
 
 type Kind string
@@ -26,51 +24,77 @@ const (
 	ToolRole      Role = "tool"
 )
 
-type BaseMessage struct {
-	content []byte
+// --- Text Message ---
+
+type TextMessage struct {
 	role    Role
-	kind    Kind
+	content string
 }
 
-func (bm BaseMessage) Role() Role {
-	return bm.role
-}
+func (m TextMessage) Role() Role      { return m.role }
+func (m TextMessage) Kind() Kind      { return TextKind }
+func (m TextMessage) Content() []byte { return []byte(m.content) }
 
-func (bm BaseMessage) Kind() Kind {
-	return bm.kind
-}
-func (bm BaseMessage) Content() []byte {
-	return bm.content
-}
-
-// NewMessage creates new `Message` with the specified `Role` and `Kind`
-func NewMessage(role Role, kind Kind, content []byte) BaseMessage {
-	return BaseMessage{
+func NewTextMessage(role Role, content string) TextMessage {
+	return TextMessage{
 		content: content,
 		role:    role,
-		kind:    kind,
 	}
 }
 
-// NewTextMessage creates new `Message` with Text kind and the specified `Role`
-func NewTextMessage(role Role, content string) BaseMessage {
-	return BaseMessage{
-		content: []byte(content),
-		role:    role,
-		kind:    TextKind,
+// --- Image Message ---
+
+type ImageMessage struct {
+	role        Role
+	content     []byte
+	description string
+}
+
+func (m ImageMessage) Role() Role          { return m.role }
+func (m ImageMessage) Kind() Kind          { return ImageKind }
+func (m ImageMessage) Content() []byte     { return m.content }
+func (m ImageMessage) Description() string { return m.description }
+
+func NewImageMessage(role Role, content []byte, description string) ImageMessage {
+	return ImageMessage{
+		content:     content,
+		description: description,
+		role:        role,
 	}
 }
 
-// NewJsonMessage marshals content and creates new `Message` with text kind and the specified `Role`
-func NewJsonMessage(role Role, content any) (BaseMessage, error) {
-	data, err := json.Marshal(content)
-	if err != nil {
-		return BaseMessage{}, err
-	}
+// --- Voice Message ---
 
-	return BaseMessage{
-		content: data,
+type VoiceMessage struct {
+	role    Role
+	content []byte
+}
+
+func (m VoiceMessage) Role() Role      { return m.role }
+func (m VoiceMessage) Kind() Kind      { return VoiceKind }
+func (m VoiceMessage) Content() []byte { return m.content }
+
+func NewVoiceMessage(role Role, content []byte) VoiceMessage {
+	return VoiceMessage{
+		content: content,
 		role:    role,
-		kind:    TextKind,
-	}, nil
+	}
+}
+
+// --- Embedding Message ---
+
+type EmbeddingMessage struct {
+	role    Role
+	content []byte
+}
+
+func (m EmbeddingMessage) Role() Role      { return m.role }
+func (m EmbeddingMessage) Kind() Kind      { return EmbeddingKind }
+func (m EmbeddingMessage) Content() []byte { return m.content }
+
+func NewEmbeddingMessage(role Role, content []byte) EmbeddingMessage {
+	return EmbeddingMessage{
+		content: content,
+		role:    role,
+	}
 }

--- a/providers/openai/speech_to_text.go
+++ b/providers/openai/speech_to_text.go
@@ -28,7 +28,7 @@ func (f Provider) SpeechToText(params SpeechToTextParams) *agency.Operation {
 				return nil, err
 			}
 
-			return agency.NewMessage(agency.AssistantRole, agency.TextKind, []byte(resp.Text)), nil
+			return agency.NewTextMessage(agency.AssistantRole, resp.Text), nil
 		},
 	)
 }

--- a/providers/openai/text_to_embedding.go
+++ b/providers/openai/text_to_embedding.go
@@ -61,7 +61,6 @@ func (p Provider) TextToEmbedding(params TextToEmbeddingParams) *agency.Operatio
 			return nil, fmt.Errorf("failed to convert embedding to bytes: %w", err)
 		}
 
-		// TODO: we have to convert []float32 to []byte. Can we optimize it?
-		return agency.NewMessage(agency.AssistantRole, agency.EmbeddingKind, bytes), nil
+		return agency.NewEmbeddingMessage(agency.AssistantRole, bytes), nil
 	})
 }

--- a/providers/openai/text_to_image.go
+++ b/providers/openai/text_to_image.go
@@ -40,7 +40,7 @@ func (p Provider) TextToImage(params TextToImageParams) *agency.Operation {
 				return nil, err
 			}
 
-			return agency.NewMessage(agency.AssistantRole, agency.ImageKind, imgBytes), nil
+			return agency.NewImageMessage(agency.AssistantRole, imgBytes, ""), nil
 		},
 	)
 }

--- a/providers/openai/text_to_speech.go
+++ b/providers/openai/text_to_speech.go
@@ -35,7 +35,7 @@ func (f Provider) TextToSpeech(params TextToSpeechParams) *agency.Operation {
 				return nil, err
 			}
 
-			return agency.NewMessage(agency.AssistantRole, agency.VoiceKind, bb), nil
+			return agency.NewVoiceMessage(agency.AssistantRole, bb), nil
 		},
 	)
 }

--- a/providers/openai/tools.go
+++ b/providers/openai/tools.go
@@ -2,17 +2,13 @@ package openai
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/neurocult/agency"
+	"github.com/sashabaranov/go-openai"
 	"github.com/sashabaranov/go-openai/jsonschema"
 )
-
-type ToolResultMessage struct {
-	agency.Message
-
-	ToolID   string
-	ToolName string
-}
 
 // FuncDef represents a function definition that can be called during the conversation.
 type FuncDef struct {
@@ -34,6 +30,49 @@ func (ds FuncDefs) getFuncDefByName(name string) *FuncDef {
 			return &f
 		}
 	}
-
 	return nil
+}
+
+func toolMessageToOpenAI(message agency.Message, toolID string) openai.ChatCompletionMessage {
+	return openai.ChatCompletionMessage{
+		Role:       string(message.Role()),
+		Content:    string(message.Content()),
+		ToolCallID: toolID,
+	}
+}
+
+func callTool(
+	ctx context.Context,
+	call openai.ToolCall,
+	defs FuncDefs,
+) (agency.Message, error) {
+	funcToCall := defs.getFuncDefByName(call.Function.Name)
+	if funcToCall == nil {
+		return nil, errors.New("function not found")
+	}
+
+	funcResult, err := funcToCall.Body(ctx, []byte(call.Function.Arguments))
+	if err != nil {
+		return funcResult, fmt.Errorf("call function %s: %w", funcToCall.Name, err)
+	}
+
+	return funcResult, nil
+}
+
+func castFuncDefsToOpenAITools(funcDefs []FuncDef) []openai.Tool {
+	tools := make([]openai.Tool, 0, len(funcDefs))
+	for _, f := range funcDefs {
+		tool := openai.Tool{
+			Type: openai.ToolTypeFunction,
+			Function: &openai.FunctionDefinition{
+				Name:        f.Name,
+				Description: f.Description,
+			},
+		}
+		if f.Parameters != nil {
+			tool.Function.Parameters = f.Parameters
+		}
+		tools = append(tools, tool)
+	}
+	return tools
 }


### PR DESCRIPTION
- Remove `BaseMessage` struct
- Instead add 4 implementations of the `Message` interface
  - TextMessage
  - ImageMessage
  - VoiceMessage
  - EmbeddingMessage
- Move helper functions from text_to_text and text_to_stream to `helper.go` and `tool.go`
- Remove unused code such as `NewJSONMessage`
- Remove explicit support for img-type from casting functions where we cast agency to openai message, the reason is that images were never used in that context + if we support images we need to support other kinds of messages anyway
- Change all examples to use new API (it looks cleaner now)